### PR TITLE
Create initial version of example modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,100 @@
+# Example infrastructure-modules for Terragrunt
+
+This repo, along with the [terragrunt-infrastructure-live-example 
+repo](https://github.com/gruntwork-io/terragrunt-infrastructure-live-example), show an example file/folder structure
+you can use with [Terragrunt](https://github.com/gruntwork-io/terragrunt) to keep your 
+[Terraform](https://www.terraform.io) code DRY. For background information, check out the [Keep your Terraform code
+DRY](https://github.com/gruntwork-io/terragrunt#keep-your-terraform-code-dry) section of the Terragrunt documentation.
+
+This repo contains the following example code:
+
+* [asg-elb-service](/asg-elb-service): An example of how to deploy an Auto Scaling Group (ASG) with an Elastic Load 
+  Balancer (ELB) in front of it. We run a dirt-simple "web server" on top of the ASG that always returns "Hello, World".
+
+* [mysql](/mysql): An example of how to deploy MySQL on top of Amazon's Relational Database Service (RDS).  
+
+Note: This code is solely for demonstration purposes. This is not production-ready code, so use at your own risk. If 
+you are interested in battle-tested, production-ready Terraform code, check out [Gruntwork](http://www.gruntwork.io/).
+
+
+
+
+
+## How do you use these modules?
+
+To use a module, create a  `terraform.tfvars` file that specifies the module you want to use as well as values for the
+input variables of that module:
+
+```hcl
+# Use Terragrunt to download the module code
+terragrunt = {
+  terraform {
+    source = "git::git@github.com:gruntwork-io/terragrunt-infrastructure-modules-example.git//path/to/module?ref=v0.0.1"
+  }
+}
+
+# Fill in the variables for that module
+foo = "bar"
+baz = 3
+```
+
+(*Note: the double slash (`//`) in the `source` URL is intentional and required. It's part of Terraform's Git syntax 
+for [module sources](https://www.terraform.io/docs/modules/sources.html).*)
+
+You then run [Terragrunt](https://github.com/gruntwork-io/terragrunt), and it will download the source code specified 
+in the `source` URL into a temporary folder, copy your `terraform.tfvars` file into that folder, and run your Terraform 
+command in that folder: 
+
+```
+> terragrunt apply
+[terragrunt] Reading Terragrunt config file at terraform.tfvars
+[terragrunt] Downloading Terraform configurations from git::git@github.com:gruntwork-io/terragrunt-infrastructure-modules-example.git//path/to/module?ref=v0.0.1
+[terragrunt] Copying files from . into /tmp/terragrunt/infrastructure-modules/path/to/module
+[terragrunt] Running command: terraform apply
+[...]
+```
+
+Check out the [terragrunt-infrastructure-live-example 
+repo](https://github.com/gruntwork-io/terragrunt-infrastructure-live-example) for examples and the [Keep your Terraform 
+code DRY documentation](https://github.com/gruntwork-io/terragrunt#keep-your-terraform-code-dry) for more info.
+
+
+
+
+
+## How do you change a module?
+
+
+### Local changes
+
+Here is how to test out changes to a module locally:
+
+1. `git clone` this repo.
+1. Update the code as necessary.
+1. Go into the folder where you have the `terraform.tfvars` file that uses a module from this repo (preferably for a 
+   dev or staging environment!).
+1. Run `terragrunt plan --terragrunt-source <LOCAL_PATH>`, where `LOCAL_PATH` is the path to your local checkout of
+   the module code. 
+1. If the plan looks good, run `terragrunt apply --terragrunt-source <LOCAL_PATH>`.   
+
+Using the `--terragrunt-source` parameter (or `TERRAGRUNT_SOURCE` environment variable) allows you to do rapid, 
+iterative, make-a-change-and-rerun development.
+
+
+### Releasing a new version
+
+When you're done testing the changes locally, here is how you release a new version:
+
+1. Update the code as necessary.
+1. Commit your changes to Git: `git commit -m "commit message"`.
+1. Add a new Git tag using one of the following options:
+    1. Using GitHub: Go to the [releases page](/releases) and click "Draft a new release".
+    1. Using Git:
+
+    ```
+    git tag -a v0.0.2 -m "tag message"
+    git push --follow-tags
+    ```
+1. Now you can use the new Git tag (e.g. `v0.0.2`) in the `ref` attribute of the `source` URL in `terraform.tfvars`.
+1. Run `terragrunt plan`.
+1. If the plan looks good, run `terragrunt apply`.   

--- a/asg-elb-service/README.md
+++ b/asg-elb-service/README.md
@@ -1,0 +1,11 @@
+# ASG with ELB Example
+
+This is an example of how to use Terraform to deploy an [Auto Scaling Group (ASG)](https://aws.amazon.com/autoscaling/) 
+with an [Elastic Load Balancer (ELB)](https://aws.amazon.com/elasticloadbalancing/) in front of it. To keep the example 
+simple, we deploy a vanilla Ubuntu AMI across the ASG and we run a dirt simple "web server" on top of it as a [User 
+Data](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) script. The "web server" always 
+returns "Hello, World". See the [root README](/README.md) for instructions on how to run this example code. 
+
+Note: This code is meant solely as a simple demonstration of how to lay out your files and folders with 
+[Terragrunt](https://github.com/gruntwork-io/terragrunt) in a way that keeps your [Terraform](https://www.terraform.io) 
+code DRY. This is not production-ready code, so use at your own risk.

--- a/asg-elb-service/main.tf
+++ b/asg-elb-service/main.tf
@@ -1,0 +1,167 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# A SIMPLE EXAMPLE OF HOW DEPLOY AN ASG WITH AN ELB IN FRONT OF IT
+# This is an example of how to use Terraform to deploy an Auto Scaling Group (ASG) with an Elastic Load
+# Balancer (ELB) in front of it. To keep the example simple, we deploy a vanilla Ubuntu AMI across the ASG and run a
+# dirt simple "web server" on top of it as a User Data script. The "web server" always returns "Hello, World".
+#
+# Note: This code is meant solely as a simple demonstration of how to lay out your files and folders with Terragrunt
+# in a way that keeps your Terraform code DRY. This is not production-ready code, so use at your own risk.
+# ---------------------------------------------------------------------------------------------------------------------
+
+provider "aws" {
+  region = "${var.aws_region}"
+}
+
+terraform {
+  # The configuration for this backend will be filled in by Terragrunt
+  backend "s3" {}
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# CREATE THE ASG
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_autoscaling_group" "webserver_example" {
+  launch_configuration = "${aws_launch_configuration.webserver_example.id}"
+  availability_zones   = ["${data.aws_availability_zones.all.names}"]
+
+  load_balancers    = ["${aws_elb.webserver_example.name}"]
+  health_check_type = "ELB"
+
+  min_size = "${var.min_size}"
+  max_size = "${var.max_size}"
+
+  tag {
+    key                 = "Name"
+    value               = "${var.name}"
+    propagate_at_launch = true
+  }
+}
+
+data "aws_availability_zones" "all" {}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# CREATE THE LAUNCH CONFIGURATION
+# This defines what runs on each EC2 Instance in the ASG. To keep the example simple, we run a plain Ubuntu AMI and
+# configure a User Data scripts that runs a dirt-simple "Hello, World" web server. In real-world usage, you'd want to
+# package the web server code into a custom AMI (rather than shoving it into User Data) and pass in the ID of that AMI
+# as a variable.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_launch_configuration" "webserver_example" {
+  image_id        = "${data.aws_ami.ubuntu.id}"
+  instance_type   = "${var.instance_type}"
+  security_groups = ["${aws_security_group.asg.id}"]
+
+  user_data = <<-EOF
+              #!/bin/bash
+              echo "Hello, World" > index.html
+              nohup busybox httpd -f -p "${var.server_port}" &
+              EOF
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["099720109477"] # Canonical
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "image-type"
+    values = ["machine"]
+  }
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-*"]
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# CREATE A SECURITY GROUP FOR THE ASG
+# To keep the example simple, we configure the EC2 Instances to allow inbound traffic from anywhere. In real-world
+# usage, you should lock the Instances down so they only allow traffic from trusted sources (e.g. the ELB).
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_security_group" "asg" {
+  name = "${var.name}-asg"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_security_group_rule" "asg_allow_http_inbound" {
+  type              = "ingress"
+  from_port         = "${var.server_port}"
+  to_port           = "${var.server_port}"
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.asg.id}"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# CREATE AN ELB TO ROUTE TRAFFIC ACROSS THE ASG
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_elb" "webserver_example" {
+  name               = "${var.name}"
+  availability_zones = ["${data.aws_availability_zones.all.names}"]
+  security_groups    = ["${aws_security_group.elb.id}"]
+
+  listener {
+    lb_port           = "${var.elb_port}"
+    lb_protocol       = "http"
+    instance_port     = "${var.server_port}"
+    instance_protocol = "http"
+  }
+
+  health_check {
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    timeout             = 3
+    interval            = 30
+    target              = "HTTP:${var.server_port}/"
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# CREATE A SECURITY GROUP FOR THE ELB
+# To keep the example simple, we configure the ELB to allow inbound requests from anywhere. We also allow it to make
+# outbound requests to anywhere so it can perform health checks. In real-world usage, you should lock the ELB down
+# so it only allows traffic to/from trusted sources.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_security_group" "elb" {
+  name = "${var.name}-elb"
+}
+
+resource "aws_security_group_rule" "elb_allow_http_inbound" {
+  type              = "ingress"
+  from_port         = "${var.elb_port}"
+  to_port           = "${var.elb_port}"
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.elb.id}"
+}
+
+resource "aws_security_group_rule" "elb_allow_all_outbound" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.elb.id}"
+}

--- a/asg-elb-service/outputs.tf
+++ b/asg-elb-service/outputs.tf
@@ -1,3 +1,7 @@
+output "url" {
+  value = "http://${aws_elb.webserver_example.dns_name}:${var.elb_port}"
+}
+
 output "elb_dns_name" {
   value = "${aws_elb.webserver_example.dns_name}"
 }

--- a/asg-elb-service/outputs.tf
+++ b/asg-elb-service/outputs.tf
@@ -1,0 +1,15 @@
+output "elb_dns_name" {
+  value = "${aws_elb.webserver_example.dns_name}"
+}
+
+output "asg_name" {
+  value = "${aws_autoscaling_group.webserver_example.name}"
+}
+
+output "asg_security_group_id" {
+  value = "${aws_security_group.asg.id}"
+}
+
+output "elb_security_group_id" {
+  value = "${aws_security_group.elb.id}"
+}

--- a/asg-elb-service/vars.tf
+++ b/asg-elb-service/vars.tf
@@ -1,0 +1,27 @@
+variable "aws_region" {
+  description = "The AWS region to deploy to (e.g. us-east-1)"
+}
+
+variable "name" {
+  description = "The name for the ASG. This name is also used to namespace all the other resources created by this module."
+}
+
+variable "instance_type" {
+  description = "The type of EC2 Instnaces to run in the ASG (e.g. t2.micro)"
+}
+
+variable "min_size" {
+  description = "The minimum number of EC2 Instances to run in the ASG"
+}
+
+variable "max_size" {
+  description = "The maximum number of EC2 Instances to run in the ASG"
+}
+
+variable "server_port" {
+  description = "The port number the web server on each EC2 Instance should listen on for HTTP requests"
+}
+
+variable "elb_port" {
+  description = "The port number the ELB should listen on for HTTP requests"
+}

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -1,0 +1,8 @@
+# MySQL on RDS Example
+
+This is an example of how to use Terraform to deploy a MySQL database on top of [Amazon's Relational Database Service
+(RDS)](https://aws.amazon.com/rds/). See the [root README](/README.md) for instructions on how to run this example code. 
+
+Note: This code is meant solely as a simple demonstration of how to lay out your files and folders with 
+[Terragrunt](https://github.com/gruntwork-io/terragrunt) in a way that keeps your [Terraform](https://www.terraform.io) 
+code DRY. This is not production-ready code, so use at your own risk.

--- a/mysql/main.tf
+++ b/mysql/main.tf
@@ -1,0 +1,33 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# A SIMPLE EXAMPLE OF HOW TO DEPLOY MYSQL ON RDS
+# This is an example of how to use Terraform to deploy a MySQL database on Amazon RDS.
+#
+# Note: This code is meant solely as a simple demonstration of how to lay out your files and folders with Terragrunt
+# in a way that keeps your Terraform code DRY. This is not production-ready code, so use at your own risk.
+# ---------------------------------------------------------------------------------------------------------------------
+
+provider "aws" {
+  region = "${var.aws_region}"
+}
+
+terraform {
+  # The configuration for this backend will be filled in by Terragrunt
+  backend "s3" {}
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# CREATE THE MYSQL DB
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_db_instance" "mysql" {
+  engine         = "mysql"
+  engine_version = "5.6.27"
+
+  name     = "${var.name}"
+  username = "${var.master_username}"
+  password = "${var.master_password}"
+
+  instance_class    = "${var.instance_class}"
+  allocated_storage = "${var.allocated_storage}"
+  storage_type      = "${var.storage_type}"
+}

--- a/mysql/main.tf
+++ b/mysql/main.tf
@@ -30,4 +30,7 @@ resource "aws_db_instance" "mysql" {
   instance_class    = "${var.instance_class}"
   allocated_storage = "${var.allocated_storage}"
   storage_type      = "${var.storage_type}"
+
+  # TODO: DO NOT COPY THIS SETTING INTO YOUR PRODUCTION DBS. It's only here to make testing this code easier!
+  skip_final_snapshot = true
 }

--- a/mysql/outputs.tf
+++ b/mysql/outputs.tf
@@ -1,0 +1,7 @@
+output "endpoint" {
+  value = "${aws_db_instance.mysql.endpoint}"
+}
+
+output "arn" {
+  value = "${aws_db_instance.mysql.arn}"
+}

--- a/mysql/outputs.tf
+++ b/mysql/outputs.tf
@@ -2,6 +2,10 @@ output "endpoint" {
   value = "${aws_db_instance.mysql.endpoint}"
 }
 
+output "db_name" {
+  value = "${aws_db_instance.mysql.name}"
+}
+
 output "arn" {
   value = "${aws_db_instance.mysql.arn}"
 }

--- a/mysql/vars.tf
+++ b/mysql/vars.tf
@@ -1,0 +1,27 @@
+variable "aws_region" {
+  description = "The AWS region to deploy to (e.g. us-east-1)"
+}
+
+variable "name" {
+  description = "The name of the DB"
+}
+
+variable "instance_class" {
+  description = "The instance class of the DB (e.g. db.t2.micro)"
+}
+
+variable "allocated_storage" {
+  description = "The amount of space, in GB, to allocate for the DB"
+}
+
+variable "storage_type" {
+  description = "The type of storage to use for the DB. Must be one of: standard, gp2, or io1."
+}
+
+variable "master_username" {
+  description = "The username for the master user of the DB"
+}
+
+variable "master_password" {
+  description = "The password for the master user of the DB"
+}


### PR DESCRIPTION
This PR creates two modules:

* `asg-elb-service`: An example of how to deploy an Auto Scaling Group (ASG) with an Elastic Load Balancer (ELB) in front of it. We run a dirt-simple "web server" on top of the ASG that always returns "Hello, World".
* `mysql`: An example of how to deploy MySQL on top of Amazon's Relational Database Service (RDS).  

I’ll submit another PR in the infra-live example repo that shows how these are used.