### PR TITLE
Update 'engine_version' for MySQL

### DIFF
--- a/mysql/main.tf
+++ b/mysql/main.tf
@@ -21,7 +21,7 @@ terraform {
 
 resource "aws_db_instance" "mysql" {
   engine         = "mysql"
-  engine_version = "5.6.27"
+  engine_version = "5.6.41"
 
   name     = "${var.name}"
   username = "${var.master_username}"


### PR DESCRIPTION
According to https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_MySQL.html?shortFooter=true#MySQL.Concepts.VersionMgmt MySQL version 5.6.27 isn't supported anymore. Hence, `terragrunt apply` will exit with an error.