### PR TITLE
Pin Terraform and provider versions

### DIFF
--- a/asg-elb-service/main.tf
+++ b/asg-elb-service/main.tf
@@ -10,14 +10,18 @@
 
 provider "aws" {
   region = var.aws_region
+
+  # Live modules pin exact provider version; generic modules let consumers pin the version.
+  version = "= 2.40.0"
 }
 
 terraform {
   # The configuration for this backend will be filled in by Terragrunt
   backend "s3" {}
 
+  # Live modules pin exact Terraform version; generic modules let consumers pin the version.
   # The latest version of Terragrunt (v0.19.0 and above) requires Terraform 0.12.0 or above.
-  required_version = ">= 0.12.0"
+  required_version = "= 0.12.16"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/asg-elb-service/main.tf
+++ b/asg-elb-service/main.tf
@@ -157,7 +157,7 @@ resource "aws_security_group_rule" "elb_allow_http_inbound" {
   to_port           = var.elb_port
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.elb.id}"
+  security_group_id = aws_security_group.elb.id
 }
 
 resource "aws_security_group_rule" "elb_allow_all_outbound" {

--- a/asg-elb-service/main.tf
+++ b/asg-elb-service/main.tf
@@ -21,7 +21,7 @@ terraform {
 
   # Live modules pin exact Terraform version; generic modules let consumers pin the version.
   # The latest version of Terragrunt (v0.19.0 and above) requires Terraform 0.12.0 or above.
-  required_version = "= 0.12.16"
+  required_version = "= 0.12.17"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/mysql/main.tf
+++ b/mysql/main.tf
@@ -19,7 +19,7 @@ terraform {
 
   # Live modules pin exact Terraform version; generic modules let consumers pin the version.
   # The latest version of Terragrunt (v0.19.0 and above) requires Terraform 0.12.0 or above.
-  required_version = "= 0.12.16"
+  required_version = "= 0.12.17"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/mysql/main.tf
+++ b/mysql/main.tf
@@ -8,14 +8,18 @@
 
 provider "aws" {
   region = var.aws_region
+
+  # Live modules pin exact provider version; generic modules let consumers pin the version.
+  version = "= 2.40.0"
 }
 
 terraform {
   # The configuration for this backend will be filled in by Terragrunt
   backend "s3" {}
 
+  # Live modules pin exact Terraform version; generic modules let consumers pin the version.
   # The latest version of Terragrunt (v0.19.0 and above) requires Terraform 0.12.0 or above.
-  required_version = ">= 0.12.0"
+  required_version = "= 0.12.16"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Based on guidance in _Terraform: Up & Running_ second edition, live modules should pin the versions of Terraform and the providers so testing and deployment are consistent; and to avoid deployment using a different Terraform version corrupting the state file.

This PR updates the live module example to be consistent with that so readers will see a "real" version of the thing about which they're reading.