### PR TITLE
Update terraform required provider syntax

### DIFF
--- a/asg-elb-service/main.tf
+++ b/asg-elb-service/main.tf
@@ -15,9 +15,7 @@ terraform {
 
   # Live modules pin exact provider version; generic modules let consumers pin the version.
   required_providers {
-    aws = {
-      version = "= 2.40.0"
-    }
+    aws = "= 2.40.0"
   }
 }
 

--- a/mysql/main.tf
+++ b/mysql/main.tf
@@ -13,9 +13,7 @@ terraform {
 
   # Live modules pin exact provider version; generic modules let consumers pin the version.
   required_providers {
-    aws = {
-      version = "= 2.40.0"
-    }
+    aws = "= 2.40.0"
   }
 }
 


### PR DESCRIPTION
Resolving the below error while running the terraform init

` 
There are some problems with the configuration, described below.

The Terraform configuration must be valid before initialization so that
Terraform can determine which modules and providers need to be installed.

Error: Invalid version constraint

A string value is required for aws.
`