### PR TITLE
Update repo to work with Terraform 0.13.x

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/gruntwork-io/pre-commit
+    rev:  v0.1.9
+    hooks:
+      - id: terraform-fmt
+

--- a/asg-elb-service/main.tf
+++ b/asg-elb-service/main.tf
@@ -15,7 +15,10 @@ terraform {
 
   # Live modules pin exact provider version; generic modules let consumers pin the version.
   required_providers {
-    aws = "= 3.7.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = "= 3.7.0"
+    }
   }
 }
 

--- a/asg-elb-service/main.tf
+++ b/asg-elb-service/main.tf
@@ -10,12 +10,12 @@
 
 terraform {
   # Live modules pin exact Terraform version; generic modules let consumers pin the version.
-  # The latest version of Terragrunt (v0.19.0 and above) requires Terraform 0.12.0 or above.
-  required_version = "= 0.12.29"
+  # The latest version of Terragrunt (v0.25.1 and above) recommends Terraform 0.13.3 or above.
+  required_version = "= 0.13.3"
 
   # Live modules pin exact provider version; generic modules let consumers pin the version.
   required_providers {
-    aws = "= 3.5.0"
+    aws = "= 3.7.0"
   }
 }
 

--- a/mysql/main.tf
+++ b/mysql/main.tf
@@ -8,12 +8,12 @@
 
 terraform {
   # Live modules pin exact Terraform version; generic modules let consumers pin the version.
-  # The latest version of Terragrunt (v0.19.0 and above) requires Terraform 0.12.0 or above.
-  required_version = "= 0.12.29"
+  # The latest version of Terragrunt (v0.25.1 and above) recommends Terraform 0.13.3 or above.
+  required_version = "= 0.13.3"
 
   # Live modules pin exact provider version; generic modules let consumers pin the version.
   required_providers {
-    aws = "= 3.5.0"
+    aws = "= 3.7.0"
   }
 }
 

--- a/mysql/main.tf
+++ b/mysql/main.tf
@@ -13,7 +13,10 @@ terraform {
 
   # Live modules pin exact provider version; generic modules let consumers pin the version.
   required_providers {
-    aws = "= 3.7.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = "= 3.7.0"
+    }
   }
 }
 


### PR DESCRIPTION
This PR updates the repo to work with Terraform 0.13. Note: because this repo has examples of Terragrunt live infrastructure modules, I'm explicitly requiring TF `0.13.3` instead of simply pinning the version to `0.12.29`