### PR TITLE
[IAC-1677] Replace gofmt with goimports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,5 +2,6 @@ repos:
   - repo: https://github.com/gruntwork-io/pre-commit
     rev:  v0.1.9
     hooks:
+      - id: goimports
       - id: terraform-fmt
 


### PR DESCRIPTION
Replace gofmt with goimports in the pre-commit configuration. Note: This PR was opened using git-xargs.