### PR TITLE
Restrict provider version.

### DIFF
--- a/asg-elb-service/main.tf
+++ b/asg-elb-service/main.tf
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "= 3.7.0"
+      version = "= 3.7.0, < 4.0"
     }
   }
 }

--- a/mysql/main.tf
+++ b/mysql/main.tf
@@ -15,7 +15,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "= 3.7.0"
+      version = "= 3.7.0, < 4.0"
     }
   }
 }


### PR DESCRIPTION
Uses https://github.com/gruntwork-io/prototypes/compare/feature/aws4-lock?expand=1 and https://github.com/rhoboat/tfupdate/tree/feature/aws-version-addon to lock the AWS provider to < 4.0.