### PR TITLE
Data source: use aws_subnets over aws_subnet_ids

### DIFF
--- a/asg-elb-service/dependencies.tf
+++ b/asg-elb-service/dependencies.tf
@@ -8,6 +8,9 @@ data "aws_vpc" "default" {
   default = true
 }
 
-data "aws_subnet_ids" "default" {
-  vpc_id = data.aws_vpc.default.id
+data "aws_subnets" "default" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
 }

--- a/asg-elb-service/main.tf
+++ b/asg-elb-service/main.tf
@@ -28,7 +28,7 @@ terraform {
 
 resource "aws_autoscaling_group" "webserver_example" {
   launch_configuration = aws_launch_configuration.webserver_example.id
-  vpc_zone_identifier  = data.aws_subnet_ids.default.ids
+  vpc_zone_identifier  = data.aws_subnets.default.ids
 
   load_balancers    = [aws_elb.webserver_example.name]
   health_check_type = "ELB"
@@ -117,7 +117,7 @@ resource "aws_security_group_rule" "asg_allow_http_inbound" {
 
 resource "aws_elb" "webserver_example" {
   name            = var.name
-  subnets         = data.aws_subnet_ids.default.ids
+  subnets         = data.aws_subnets.default.ids
   security_groups = [aws_security_group.elb.id]
 
   listener {


### PR DESCRIPTION
## Description

Addresses _internal_ aws v4 compatibility.

This updates example code only. The provider version handles both old and new data sources, so users have no updates to make on their end as a result of this change. It is backward compatible. When we bump the provider version to at least 3.75 _and/or_ remove the 4.x lock, that's when we have a potential backward incompatibility, but most likely, even that update will be functionally backward compatible, i.e., only require an update to the provider version, and no config changes, imports, or state migrations.

### Documentation

N/A

## TODOs

- [x] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [x] Update the docs.
- [x] Keep the changes backwards compatible where possible.
- [x] Run the pre-commit checks successfully.
- [x] Run the relevant tests successfully.
- ~Ensure any 3rd party code adheres with our license policy: https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378~
- [ ] _Maintainers Only._ If necessary, release a new version of this repo.
- ~_Maintainers Only._ If there were backwards incompatible changes, include a migration guide in the release notes.~
- [ ] _Maintainers Only._ Add to the next version of the monthly newsletter (see https://www.notion.so/gruntwork/Monthly-Newsletter-9198cbe7f8914d4abce23dca7b435f43).


## Related Issues
Addresses https://github.com/gruntwork-io/cloud-chasers/issues/20
