### PR TITLE
Add example boilerplate template for scaffolding

### DIFF
--- a/modules/ecs-fargate-service/.boilerplate/README.md
+++ b/modules/ecs-fargate-service/.boilerplate/README.md
@@ -1,0 +1,11 @@
+# Terragrunt scaffold custom template example
+
+This is an example of how to create a custom [boilerplate](https://github.com/gruntwork-io/boilerplate) template that
+will be used automatically for code generation when this module is used in [Terragrunt 
+scaffolding](https://terragrunt.gruntwork.io/docs/features/scaffold/).
+
+- You can define input variables and other configuration in `boilerplate.yml`. E.g., This example defines a variable
+  called `TeamName`, which you've set to: `{{ .TeamName }}`.
+- Any files in this folder will be generated as part of scaffolding.
+
+See [Introducing Boilerplate](https://blog.gruntwork.io/introducing-boilerplate-6d796444ecf6) for more info.

--- a/modules/ecs-fargate-service/.boilerplate/boilerplate.yml
+++ b/modules/ecs-fargate-service/.boilerplate/boilerplate.yml
@@ -1,0 +1,4 @@
+variables:
+  - name: TeamName
+    description: The name of the team using this module
+    type: string

--- a/modules/ecs-fargate-service/.boilerplate/terragrunt.hcl
+++ b/modules/ecs-fargate-service/.boilerplate/terragrunt.hcl
@@ -1,0 +1,28 @@
+terraform {
+  source = "{{ .sourceUrl }}"
+}
+
+include "root" {
+  path = find_in_parent_folders()
+}
+
+inputs = {
+  # --------------------------------------------------------------------------------------------------------------------
+  # Required input variables
+  # --------------------------------------------------------------------------------------------------------------------
+  {{ range .requiredVariables }}
+  # Description: {{ .Description }}
+  # Type: {{ .Type }}
+  {{ .Name }} = {{ .DefaultValuePlaceholder }}  # TODO: fill in value
+  {{ end }}
+
+  # --------------------------------------------------------------------------------------------------------------------
+  # Optional input variables
+  # Uncomment the ones you wish to set
+  # --------------------------------------------------------------------------------------------------------------------
+  {{ range .optionalVariables }}
+  # Description: {{ .Description }}
+  # Type: {{ .Type }}
+  # {{ .Name }} = {{ .DefaultValue }}
+  {{ end }}
+}


### PR DESCRIPTION
This adds an example of a custom Boilerplate template that can be used with the `terragrunt scaffold` command. See https://terragrunt.gruntwork.io/docs/features/scaffold/#custom-templates-for-scaffolding for context.